### PR TITLE
ホーム画面の投稿一覧表示機能を実装

### DIFF
--- a/src/main/java/com/example/demo/controller/HomeController.java
+++ b/src/main/java/com/example/demo/controller/HomeController.java
@@ -1,17 +1,30 @@
 package com.example.demo.controller;
 
+import java.util.List;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.servlet.ModelAndView;
 
+import com.example.demo.entity.Post;
+import com.example.demo.repository.PostRepository;
+
+import lombok.AllArgsConstructor;
+
 
 @Controller
+@AllArgsConstructor
 public class HomeController {
+	
+	private final PostRepository postRepository;
 	
 	@GetMapping("/")
 	public ModelAndView showHome(ModelAndView mav) {
 		
+		List<Post> postList = postRepository.findAll();
+		
 		mav.setViewName("home");
+		mav.addObject("postList", postList);
 		
 		return mav;
 	}

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -17,63 +17,38 @@
 <body>
     <nav th:replace="fragments :: navbar_area"></nav>
 
-        <div class="card m-4 mx-auto w-75">
-            <div class="card-body">
+    <div class="card w-75 mx-auto my-4" th:each="post : ${postList}">
+        <div class="card-body">
+            <div class="mb-3">
                 <img th:src="@{/icons/app_icon.svg}" class="rounded-circle" width="56px" height="56px"/>
-                <span class="fw-bold">user name</span>
-                <table>
-                    <tr>
-                        <td class="align-top fw-bold">ハッカソン参加経験</td>
-                        <td class="align-top px-1">1回</td>
-                    </tr>
-                    <tr>
-                        <td class="align-top fw-bold">成果物</td>
-                        <td class="align-top px-1">ハッカソン補助アプリ</td>
-                    </tr>
-                    <tr>
-                        <td class="align-top fw-bold">参加したハッカソン</td>
-                        <td class="align-top px-1">初めてのハッカソン</td>
-                    </tr>
-                    <tr>
-                        <td class="align-top align-top fw-bold">作品名</td>
-                        <td class="align-top px-1">HackathonRunner</td>
-                    </tr>
-                </table>
-                <div class="text-end">
-                    <button class="btn btn-primary">参考になった</button>
-                </div>
+                <span class="fw-bold fs-3 ms-2" th:text="${post.name}">user name</span>
             </div>
-        </div>
-
-        <div class="card m-4 mx-auto w-75">
-            <div class="card-body">
-                <img th:src="@{/icons/app_icon.svg}" class="rounded-circle" width="56px" height="56px"/>
-                <span class="fw-bold">user name</span>
-                <table>
-                    <tr>
-                        <td class="align-top fw-bold">ハッカソン参加経験</td>
-                        <td class="align-top px-1">1回</td>
-                    </tr>
-                    <tr>
-                        <td class="align-top fw-bold">成果物</td>
-                        <td class="align-top px-1">ハッカソン補助アプリ</td>
-                    </tr>
-                    <tr>
-                        <td class="align-top fw-bold">参加したハッカソン</td>
-                        <td class="align-top px-1">初めてのハッカソン</td>
-                    </tr>
-                    <tr>
-                        <td class="align-top align-top fw-bold">作品名</td>
-                        <td class="align-top px-1">HackathonRunner</td>
-                    </tr>
-                </table>
-                <div class="text-end">
-                    <button class="btn btn-outline-primary">参考になった</button>
-                </div>
-            </div>
+            <table class="table table-borderless">
+                <tr th:switch="${post.hackathon}">
+                    <th class="w-50">ハッカソン参加経験</th>
+                    <td th:case=0>なし</td>
+                    <td th:case=1>1, 2回</td>
+                    <td th:case=2>3回以上</td>
+                </tr>
+                <tr th:switch="${post.portfolio}">
+                    <th class="w-50">ツール（アプリ）<br>開発経験</th>
+                    <td th:case=0>なし</td>
+                    <td th:case=1>簡単なツール（アプリ）を作ったことがある</td>
+                    <td th:case=2>ツール（アプリ）を公開したことがある</td>
+                    <td th:case=3>ツール（アプリ）開発で、設計・実装・テストを経験したがある</td>
+                </tr>
+                <tr>
+                    <th class="w-50">参加したハッカソン</th>
+                    <td th:text="${post.event}"></td>
+                </tr>
+                <tr>
+                    <th class="w-50">作品名</th>
+                    <td th:text="${post.work}"></td>
+                </tr>
+            </table>
         </div>
     </div>
-
+    
     <!--bootstrap js-->
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>


### PR DESCRIPTION
# 詳細
ホーム画面の投稿一覧表示機能の実装に加えて、投稿内容のUI(参考になるボタン、各要素の配置やサイズ)を変更した。

# スクリーンショット（変更後）
<img width="1919" alt="p5q7cfIYpV" src="https://user-images.githubusercontent.com/62631497/187065587-1feb3d66-32c8-4e2b-a82e-2cd6a358b552.png">

# スクリーンショット（変更前）
<img width="1920" alt="FqTCar06W2" src="https://user-images.githubusercontent.com/62631497/187065593-10751f43-65f7-4959-b780-833f9915f438.png">

