### PR TITLE
ナビゲーションバーに「募集」リンクを追加

### DIFF
--- a/src/main/resources/templates/fragments.html
+++ b/src/main/resources/templates/fragments.html
@@ -11,9 +11,21 @@
                 <img th:src="@{/icons/app_icon.svg}" class="app-icon" width="52px" height="52px"/>
                 <span><i th:text="#{text.header}"></i></span>
             </a>
-            <div class="d-flex">
-                <a class="btn btn-outline-light mx-2 btn-lg" th:href="@{/showQuestion}" th:text="#{button.question}"></a>
-                <a class="btn btn-outline-light mx-2 btn-lg" th:href="@{/showPostForm}" th:text="#{button.post}"></a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarTogglerDemo02" aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarTogglerDemo02">
+                <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+                    <li class="nav-item me-3">
+                        <a class="nav-link active fs-5" th:href="@{/showQuestion}">診断</a>
+                    </li>
+                    <li class="nav-item me-3">
+                        <a class="nav-link active fs-5" th:href="@{/showPostForm}">投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link active fs-5" th:href="@{/showRecruitmentForm}">募集</a>
+                    </li>
+                </ul>
             </div>
         </div>
     </nav>

--- a/target/classes/templates/fragments.html
+++ b/target/classes/templates/fragments.html
@@ -11,9 +11,21 @@
                 <img th:src="@{/icons/app_icon.svg}" class="app-icon" width="52px" height="52px"/>
                 <span><i th:text="#{text.header}"></i></span>
             </a>
-            <div class="d-flex">
-                <a class="btn btn-outline-light mx-2 btn-lg" th:href="@{/showQuestion}" th:text="#{button.question}"></a>
-                <a class="btn btn-outline-light mx-2 btn-lg" th:href="@{/showPostForm}" th:text="#{button.post}"></a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarTogglerDemo02" aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarTogglerDemo02">
+                <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+                    <li class="nav-item me-3">
+                        <a class="nav-link active fs-5" th:href="@{/showQuestion}">診断</a>
+                    </li>
+                    <li class="nav-item me-3">
+                        <a class="nav-link active fs-5" th:href="@{/showPostForm}">投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link active fs-5" th:href="@{/showRecruitmentForm}">募集</a>
+                    </li>
+                </ul>
             </div>
         </div>
     </nav>


### PR DESCRIPTION
# 変更点(ナビゲーションバーのUI)
- 「募集」リンクを追加
- 「診断する」「投稿する」ボタンを「診断」「投稿」リンクに変更
- スマホ画面幅の時に、リンク（ボタン）をToggler（ハンバーガーメニュー）で表示するように変更

# スクリーンショット
- 変更前
<img width="1350" alt="chrome_42k16Pjuwc" src="https://user-images.githubusercontent.com/62631497/196312422-33980502-ef45-40d5-bf93-add7839dd041.png">
<img width="484" alt="chrome_6BmnjDpJdQ" src="https://user-images.githubusercontent.com/62631497/196312447-b488f3b9-647f-49a7-b1db-598c47d4db9d.png">

- 変更後
<img width="1351" alt="chrome_CozaQeQiIu" src="https://user-images.githubusercontent.com/62631497/196312475-f0580e2c-0874-45bc-ba4f-de3b9a03400e.png">
<img width="483" alt="chrome_QkDaEBiGIf" src="https://user-images.githubusercontent.com/62631497/196312488-1ede69cb-fbfa-4db7-b6ba-59e1a755dbf4.png">
<img width="483" alt="chrome_kJ9FvvCUqd" src="https://user-images.githubusercontent.com/62631497/196312496-b4629ddc-b4e5-4bd7-b39e-d4c51728a9f3.png">
