### PR TITLE
締切日の表示フォーマットをyyyy/MM/dd形式に変更、締切日が過ぎた募集を表示しないように変更

### DIFF
--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -270,7 +270,7 @@
 		</div>
 
 		<div class="tab-pane" id="recruitment" role="tabpanel" aria-labelledby="tab2">
-            <div class="list-group w-75 mx-auto my-4" th:each="recruitment : ${recruitmentList}">
+            <div class="list-group w-75 mx-auto my-4" th:each="recruitment : ${recruitmentList}" th:if="${#dates.format(recruitment.deadline, 'yyyy/MM/dd') ge #dates.format(#dates.createNow(), 'yyyy/MM/dd')}">
                 <div class="list-group-item">
                     <div class="container my-3">
                         <div class="row">

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -280,7 +280,7 @@
                             </div>
                             <div class="col-12 col-sm-6 d-grid gap-2 d-md-flex justify-content-md-end">
                                 <p class="my-3 d-flex btn-lg text-center border border-1 border-primary">
-                                    <span th:text="${recruitment.deadline}"></span>まで募集中！
+                                    <span th:text="${#dates.format(recruitment.deadline, 'yyyy/MM/dd')}"></span>まで募集中！
                                 </p>
                             </div>
                         </div>

--- a/target/classes/templates/home.html
+++ b/target/classes/templates/home.html
@@ -270,7 +270,7 @@
 		</div>
 
 		<div class="tab-pane" id="recruitment" role="tabpanel" aria-labelledby="tab2">
-            <div class="list-group w-75 mx-auto my-4" th:each="recruitment : ${recruitmentList}">
+            <div class="list-group w-75 mx-auto my-4" th:each="recruitment : ${recruitmentList}" th:if="${#dates.format(recruitment.deadline, 'yyyy/MM/dd') ge #dates.format(#dates.createNow(), 'yyyy/MM/dd')}">
                 <div class="list-group-item">
                     <div class="container my-3">
                         <div class="row">

--- a/target/classes/templates/home.html
+++ b/target/classes/templates/home.html
@@ -280,7 +280,7 @@
                             </div>
                             <div class="col-12 col-sm-6 d-grid gap-2 d-md-flex justify-content-md-end">
                                 <p class="my-3 d-flex btn-lg text-center border border-1 border-primary">
-                                    <span th:text="${recruitment.deadline}"></span>まで募集中！
+                                    <span th:text="${#dates.format(recruitment.deadline, 'yyyy/MM/dd')}"></span>まで募集中！
                                 </p>
                             </div>
                         </div>


### PR DESCRIPTION
# 変更点
- 募集一覧における、締切日の表示フォーマットをyyyy/MM/dd形式に変更
- 締切日が過ぎた募集を表示しないような制御を追加

# スクリーンショット
<img width="1368" alt="chrome_0HYWv41Idz" src="https://user-images.githubusercontent.com/62631497/197319871-e927b9d0-286c-408c-bc65-79e1d69e78ee.png">
