### PR TITLE
ホーム画面における各機能紹介の縦方向余白を揃える

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ target/**/repository/
 target/**/service/
 target/**/utils/
 HackathonRunnerApplication.class
+target/classes/META-INF/
 target/classes/static/
 target/classes/templates/
 target/classes/*.properties

--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,12 @@ target/**/form/
 target/**/repository/
 target/**/service/
 target/**/utils/
-target/**/static/
-target/**/templates/
 HackathonRunnerApplication.class
+target/classes/static/
+target/classes/templates/
 target/classes/*.properties
-target/test-classes
+target/dependency/
+target/test-classes/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/

--- a/src/main/resources/static/css/home.css
+++ b/src/main/resources/static/css/home.css
@@ -21,7 +21,7 @@
 }
 
 .left-side-introduction{
-    margin-top:100px;
+    margin-top:200px;
     padding-left:calc(160%/6);
     padding-right:10%;
     padding-top:50px;


### PR DESCRIPTION
他にも、git管理不要なディレクトリを.gitignoreに追加しました。

# スクリーンショット（ホーム画面の変更箇所）
- 変更前
<img width="962" alt="chrome_ZEzh1HGJ3S" src="https://user-images.githubusercontent.com/62631497/201506825-ce825706-6037-4fb0-83a8-1be3ebe27ede.png">

- 変更後
<img width="962" alt="chrome_NV4MIjOVUR (2)" src="https://user-images.githubusercontent.com/62631497/201506830-635bf359-5b48-4a89-ac5a-c870bca9c942.png">
