### PR TITLE
ナビゲーションバーver4.0の実装

### DIFF
--- a/src/main/resources/templates/fragments.html
+++ b/src/main/resources/templates/fragments.html
@@ -19,11 +19,25 @@
                     <li class="nav-item me-3">
                         <a class="nav-link active fs-5" th:href="@{/showQuestion}">診断</a>
                     </li>
-                    <li class="nav-item me-3">
-                        <a class="nav-link active fs-5" th:href="@{/showPostForm}">投稿</a>
+                    <li class="nav-item dropdown me-3">
+                        <a class="nav-link active fs-5 dropdown-toggle" href="#" id="navbarDropdownPost" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                            投稿
+                        </a>
+                        <ul class="dropdown-menu" aria-labelledby="navbarDropdownPost">
+                            <li><a class="dropdown-item mb-4" th:href="@{/showPostForm}">投稿する</a></li>
+                            <!-- <li><hr class="dropdown-divider"></li> -->
+                            <li><a class="dropdown-item" th:href="@{/showPostList}">投稿一覧</a></li>
+                        </ul>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link active fs-5" th:href="@{/showRecruitmentForm}">募集</a>
+                    <li class="nav-item dropdown">
+                        <a class="nav-link active fs-5 dropdown-toggle" href="#" id="navbarDropdownRecruitment" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                            チームメンバー募集
+                        </a>
+                        <ul class="dropdown-menu" aria-labelledby="navbarDropdownRecruitment">
+                            <li><a class="dropdown-item mb-4" th:href="@{/showRecruitmentForm}">募集する</a></li>
+                            <!-- <li><hr class="dropdown-divider"></li> -->
+                            <li><a class="dropdown-item" th:href="@{/showRecruitmentList}">募集一覧</a></li>
+                        </ul>
                     </li>
                 </ul>
             </div>

--- a/src/main/resources/templates/fragments.html
+++ b/src/main/resources/templates/fragments.html
@@ -24,8 +24,8 @@
                             投稿
                         </a>
                         <ul class="dropdown-menu" aria-labelledby="navbarDropdownPost">
-                            <li><a class="dropdown-item mb-4" th:href="@{/showPostForm}">投稿する</a></li>
-                            <!-- <li><hr class="dropdown-divider"></li> -->
+                            <li><a class="dropdown-item" th:href="@{/showPostForm}">投稿する</a></li>
+                            <li><hr class="dropdown-divider"></li>
                             <li><a class="dropdown-item" th:href="@{/showPostList}">投稿一覧</a></li>
                         </ul>
                     </li>
@@ -34,8 +34,8 @@
                             チームメンバー募集
                         </a>
                         <ul class="dropdown-menu" aria-labelledby="navbarDropdownRecruitment">
-                            <li><a class="dropdown-item mb-4" th:href="@{/showRecruitmentForm}">募集する</a></li>
-                            <!-- <li><hr class="dropdown-divider"></li> -->
+                            <li><a class="dropdown-item" th:href="@{/showRecruitmentForm}">募集する</a></li>
+                            <li><hr class="dropdown-divider"></li>
                             <li><a class="dropdown-item" th:href="@{/showRecruitmentList}">募集一覧</a></li>
                         </ul>
                     </li>


### PR DESCRIPTION
# 変更点
- 「投稿」のリンクを、投稿フォームへのリンクと、投稿一覧へのリンクを含むドロップダウンに変更
- 「募集」のリンクを、募集フォームへのリンクと、募集一覧へのリンクを含むドロップダウンに変更、「募集」から「チームメンバー募集」にテキストを変更

# スクリーンショット（ナビゲーションバー部分のみ）
- 変更後
<img width="1908" alt="chrome_gfOnJ65p7g" src="https://user-images.githubusercontent.com/62631497/202880429-5669bac1-e157-44bf-a40b-42cca1784403.png">

- 変更前
<img width="1908" alt="chrome_EeJfCoIzhn" src="https://user-images.githubusercontent.com/62631497/202880433-a158e562-d1b3-4266-877b-681a2c42e514.png">
