### PR TITLE
ローカルで本番環境とは異なるデータベースに接続するできるように変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ target/test-classes/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
+*.sql
+*.db
 
 ### STS ###
 .apt_generated

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,11 @@
       <scope>runtime</scope>  
       <optional>true</optional> 
     </dependency>  
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>runtime</scope>
+    </dependency>
     <dependency> 
       <groupId>org.projectlombok</groupId>  
       <artifactId>lombok</artifactId>  

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -1,0 +1,13 @@
+spring.datasource.url=jdbc:h2:file:./target/db/testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.sql.init.encoding=UTF-8
+spring.sql.init.mode=always
+spring.sql.init.schema-locations=classpath:schema.sql
+spring.sql.init.data-locations=classpath:data.sql
+
+spring.h2.console.enabled=true
+
+logging.level.org.springframework.jdbc.core=DEBUG

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -1,0 +1,8 @@
+logging.level.org.springframework.jdbc.core=DEBUG
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+spring.datasource.url=jdbc:postgresql://${AZ_DATABASE_NAME}.postgres.database.azure.com:5432/${AZ_TABLE_NAME}?sslmode=require
+spring.datasource.username=${AZ_POSTGRESQL_NON_ADMIN_USERNAME}
+spring.datasource.password=${AZ_POSTGRESQL_NON_ADMIN_PASSWORD}
+
+spring.jpa.show-sql=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,2 @@
-logging.level.org.springframework.jdbc.core=DEBUG
-spring.datasource.driver-class-name=org.postgresql.Driver
-
-spring.datasource.url=jdbc:postgresql://${AZ_DATABASE_NAME}.postgres.database.azure.com:5432/${AZ_TABLE_NAME}?sslmode=require
-spring.datasource.username=${AZ_POSTGRESQL_NON_ADMIN_USERNAME}
-spring.datasource.password=${AZ_POSTGRESQL_NON_ADMIN_PASSWORD}
-
-spring.jpa.show-sql=true
+spring.profiles.active=development
+#spring.profiles.active=production


### PR DESCRIPTION
# 変更点
- ローカルと本番環境とで接続するデータベースを切り替えられるように変更
  - 切り替え方法: src/main/resources/application.propertiesのspring.profiles.activeを変更させる
  （ローカル: development, 本番環境: production）
- 起動時にローカルのデータベースでテーブル作成を行うためのSQL(schema.sql)と、仮の初期データを挿入するためのSQL(data.sql)を作成（.gitignoreに設定したので、別途共有します）
- ローカルでは、環境構築を必要としないH2データベースを使うため、pom.xmlにH2を追加

# テスト
- H2のコンソール上([http://localhost:8080/h2-console](http://localhost:8080/h2-console))で確認
- スクリーンショット(postテーブル)
<img width="1198" alt="msoC8rxFaZ" src="https://user-images.githubusercontent.com/62631497/210480739-cb7bf3c3-f39b-4daa-874a-11a7b471e17e.png">

- スクリーンショット(recruitmentテーブル)
<img width="677" alt="chrome_JQur3iRiWF" src="https://user-images.githubusercontent.com/62631497/210480801-2df44470-7d20-4073-b60c-95e5a72f7921.png">
